### PR TITLE
Delete after edit

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -33,4 +33,4 @@ Maintainer: https://github.com/farmersedgeinc
 EOF
 
 mkdir -p out
-dpkg-deb --build "$PKGDIR" "out/yaml-crypt.$GOARCH.deb"
+dpkg-deb --root-owner-group --build "$PKGDIR" "out/yaml-crypt.$GOARCH.deb"

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -69,7 +69,11 @@ var editCmd = &cobra.Command{
 			return err
 		}
 		//encrypt
-		return actions.Encrypt([]*actions.File{&file}, &cache, &config.Provider, int(threads))
+		err = actions.Encrypt([]*actions.File{&file}, &cache, &config.Provider, int(threads))
+		if err != nil {
+			return err
+		}
+		return os.Remove(file.DecryptedPath)
 	},
 }
 


### PR DESCRIPTION
now that the ability to cache future decryptions isn't tied to the existence of the decrypted files, no need to leave a mess!