### PR TITLE
[cmd/edit] delete decrypted file after encrypting it

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -69,7 +69,11 @@ var editCmd = &cobra.Command{
 			return err
 		}
 		//encrypt
-		return actions.Encrypt([]*actions.File{&file}, &cache, &config.Provider, int(threads))
+		err = actions.Encrypt([]*actions.File{&file}, &cache, &config.Provider, int(threads))
+		if err != nil {
+			return err
+		}
+		return os.Remove(file.DecryptedPath)
 	},
 }
 


### PR DESCRIPTION
now that the ability to cache future decryptions isn't tied to the existence of the decrypted files, no need to leave a mess!