### PR TITLE
Fix old cache retrieval

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -102,7 +102,7 @@ func (c *Cache) Encrypt(plaintext string) ([]byte, bool, error) {
 		if err != nil {
 			return []byte{}, false, err
 		}
-		err = c.Add(plaintext, ciphertext)
+		err = c.add(plaintext, ciphertext)
 		return ciphertext, true, err
 	}
 	return []byte{}, false, nil
@@ -123,7 +123,7 @@ func (c *Cache) Decrypt(ciphertext []byte) (string, bool, error) {
 			return "", false, err
 		}
 		plaintext := string(value)
-		err = c.Add(plaintext, ciphertext)
+		err = c.add(plaintext, ciphertext)
 		return plaintext, true, err
 	}
 	return "", false, nil
@@ -133,7 +133,11 @@ func (c *Cache) Decrypt(ciphertext []byte) (string, bool, error) {
 func (c *Cache) Add(plaintext string, ciphertext []byte) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+	return c.add(plaintext, ciphertext)
+}
 
+// Add a (plaintext, ciphertext) pair to the young cache.
+func (c *Cache) add(plaintext string, ciphertext []byte) error {
 	err := c.young.Put(plaintextToKey(plaintext), ciphertext)
 	if err != nil {
 		return err

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCache(t *testing.T) {
 	// make the cache a lot smaller to make it quicker to test LRU behavior
-	YoungCacheSize = 1024 * 100
+	YoungCacheSize = 10000
 	// check out an arbitrary repo in order to provide a directory and config for the cache
 	repos, err := fixtures.Repos()
 	if err != nil {
@@ -60,6 +60,8 @@ func TestCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	getItems(t, &cache, 0, false)
+	getItems(t, &cache, 1, false)
+	getItems(t, &cache, 19, true)
 	err = cache.Close()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
turns out going
```
mutex.Lock()
mutex.Lock()
mutex.Unlock()
mutex.Unlock()
```
doesn't work so well. the inner locking came from a call to `Add()`, so i split the functional part of `Add()` to a private method and kept the public method as just a mutex'd wrapper.