### PR TITLE
Disable CGO

### DIFF
--- a/build-tarball.sh
+++ b/build-tarball.sh
@@ -54,7 +54,7 @@ function ldflags {
 
 BIN_PATH="$(pkg_file /usr/bin/yaml-crypt)"
 # Install Binary
-GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$(ldflags)" -o "$BIN_PATH"
+CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$(ldflags)" -o "$BIN_PATH"
 
 # Install Completions
 install_completion bash /etc/bash_completion.d/yaml-crypt

--- a/build-tarball.sh
+++ b/build-tarball.sh
@@ -48,7 +48,7 @@ EOF
 
 function ldflags {
     printf -- \
-        "-X 'github.com/farmersedgeinc/yaml-crypt/cmd.version=%s'" \
+        "-s -w -X 'github.com/farmersedgeinc/yaml-crypt/cmd.version=%s'" \
         "${VERSION#refs/tags/v}"
 }
 


### PR DESCRIPTION
This makes the binaries truly portable by no longer relying on the system libc