### PR TITLE
--no-cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Test
         run: |
           printf %s "$GOOGLE_CREDENTIALS" > "$GOOGLE_APPLICATION_CREDENTIALS"
+          go vet ./...
           go test -v ./...
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ RUN helm plugin install https://github.com/jkroepke/helm-secrets
 RUN curl -L "https://github.com/farmersedgeinc/yaml-crypt/releases/download/v$YAML_CRYPT_VERSION/yaml-crypt.linux.$ARCH.tar.gz" | tar -xzvC /
 # enable helm-secrets backend
 ENV HELM_SECRETS_BACKEND=/usr/share/yaml-crypt/helm-secrets/_backend.sh
+# disable cache
+ENV SECRET_BACKEND_ARGS --no-cache
 ```
 
 ## Security Notes

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -31,7 +31,7 @@ var DecryptCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		cache, err := cache.Setup(config)
+		cache, err := cache.Setup(config, disableCache)
 		if err != nil {
 			return err
 		}
@@ -65,7 +65,7 @@ var DecryptCmd = &cobra.Command{
 				files = append(files, &file)
 			}
 		}
-		return actions.Decrypt(files, DecryptFlags.Plain, DecryptFlags.Stdout, &cache, &config.Provider, int(threads), retries, timeout, progress)
+		return actions.Decrypt(files, DecryptFlags.Plain, DecryptFlags.Stdout, cache, &config.Provider, int(threads), retries, timeout, progress)
 	},
 }
 

--- a/cmd/decrypt_value.go
+++ b/cmd/decrypt_value.go
@@ -45,12 +45,12 @@ func DecryptValue(stdin io.Reader, stdout io.Writer, no_newline bool) error {
 		if err != nil {
 			return err
 		}
-		cache, err := cache.Setup(config)
+		cache, err := cache.Setup(config, disableCache)
 		if err != nil {
 			return err
 		}
 		defer cache.Close()
-		plaintext, err = actions.DecryptCiphertext(ciphertext, &cache, &config.Provider, retries, timeout)
+		plaintext, err = actions.DecryptCiphertext(ciphertext, cache, &config.Provider, retries, timeout)
 		return err
 	}()
 	if err != nil {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -53,12 +53,12 @@ var editCmd = &cobra.Command{
 
 		// decrypt
 		err = func() error {
-			cache, err := cache.Setup(config)
+			cache, err := cache.Setup(config, disableCache)
 			if err != nil {
 				return err
 			}
 			defer cache.Close()
-			return actions.Decrypt([]*actions.File{&file}, false, false, &cache, &config.Provider, int(threads), retries, timeout, progress)
+			return actions.Decrypt([]*actions.File{&file}, false, false, cache, &config.Provider, int(threads), retries, timeout, progress)
 		}()
 		if err != nil {
 			return err
@@ -76,14 +76,14 @@ var editCmd = &cobra.Command{
 		}
 
 		// re-open cache
-		cache, err := cache.Setup(config)
+		cache, err := cache.Setup(config, disableCache)
 		if err != nil {
 			return err
 		}
 		defer cache.Close()
 
 		// encrypt
-		err = actions.Encrypt([]*actions.File{&file}, &cache, &config.Provider, int(threads), retries, timeout, progress)
+		err = actions.Encrypt([]*actions.File{&file}, cache, &config.Provider, int(threads), retries, timeout, progress)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ var editCmd = &cobra.Command{
 			return err
 		}
 		// update plain file
-		return actions.Decrypt([]*actions.File{&file}, true, false, &cache, &config.Provider, int(threads), retries, timeout, progress)
+		return actions.Decrypt([]*actions.File{&file}, true, false, cache, &config.Provider, int(threads), retries, timeout, progress)
 	},
 }
 

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -20,7 +20,7 @@ var EncryptCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		cache, err := cache.Setup(config)
+		cache, err := cache.Setup(config, disableCache)
 		if err != nil {
 			return err
 		}
@@ -49,7 +49,7 @@ var EncryptCmd = &cobra.Command{
 				files = append(files, &file)
 			}
 		}
-		return actions.Encrypt(files, &cache, &config.Provider, int(threads), retries, timeout, progress)
+		return actions.Encrypt(files, cache, &config.Provider, int(threads), retries, timeout, progress)
 	},
 }
 

--- a/cmd/encrypt_value.go
+++ b/cmd/encrypt_value.go
@@ -52,12 +52,12 @@ func EncryptValue(stdin io.Reader, stdout io.Writer, multiline bool) error {
 		if err != nil {
 			return err
 		}
-		cache, err := cache.Setup(config)
+		cache, err := cache.Setup(config, disableCache)
 		if err != nil {
 			return err
 		}
 		defer cache.Close()
-		ciphertext, err = actions.EncryptPlaintext(string(plaintext), &cache, &config.Provider, retries, timeout)
+		ciphertext, err = actions.EncryptPlaintext(string(plaintext), cache, &config.Provider, retries, timeout)
 		return err
 	}()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 var threads uint
 var progress bool
+var disableCache bool
 var retries uint
 var timeout time.Duration
 
@@ -30,6 +31,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().UintVarP(&threads, "threads", "t", 16, "number of crypto operations to run in parallel")
 	rootCmd.PersistentFlags().BoolVarP(&progress, "progress", "", true, "show progress bar")
+	rootCmd.PersistentFlags().BoolVarP(&disableCache, "no-cache", "C", false, "disable caching plaintexts to disk")
 	rootCmd.PersistentFlags().UintVarP(&retries, "retries", "r", 5, "number of retries for failed crypto service operations")
 	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "", 10*time.Second, "timeout for crypto service operations")
 }

--- a/pkg/actions/crypto.go
+++ b/pkg/actions/crypto.go
@@ -14,7 +14,7 @@ import (
 
 type nothing struct{}
 
-func Decrypt(files []*File, plain bool, stdout bool, cache *cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
+func Decrypt(files []*File, plain bool, stdout bool, cache cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
 	// read in files, populate the set of ciphertexts
 	nodes := make([]yamlv3.Node, len(files))
 	ciphertextSet := map[string]nothing{}
@@ -68,7 +68,7 @@ func Decrypt(files []*File, plain bool, stdout bool, cache *cache.Cache, provide
 	return nil
 }
 
-func Encrypt(files []*File, cache *cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
+func Encrypt(files []*File, cache cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
 	// read in decrypted files, populate the set of plaintexts
 	var err error
 	decryptedNodes := make([]yamlv3.Node, len(files))
@@ -147,7 +147,7 @@ func addTaggedValuesToSet(set *map[string]nothing, node *yamlv3.Node, tag string
 	return
 }
 
-func encryptPlaintexts(set *map[string]nothing, cache *cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
+func encryptPlaintexts(set *map[string]nothing, cache cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
 	plaintexts := make([]string, 0, len(*set))
 	for k := range *set {
 		plaintexts = append(plaintexts, k)
@@ -159,7 +159,7 @@ func encryptPlaintexts(set *map[string]nothing, cache *cache.Cache, provider *cr
 	return err
 }
 
-func EncryptPlaintext(plaintext string, cache *cache.Cache, provider *crypto.Provider, retries uint, timeout time.Duration) ([]byte, error) {
+func EncryptPlaintext(plaintext string, cache cache.Cache, provider *crypto.Provider, retries uint, timeout time.Duration) ([]byte, error) {
 	ciphertext, ok, err := cache.Encrypt(plaintext, []byte{})
 	if err != nil {
 		return []byte{}, fmt.Errorf("Error looking up plaintext in cache: %w", err)
@@ -178,7 +178,7 @@ func EncryptPlaintext(plaintext string, cache *cache.Cache, provider *crypto.Pro
 	return ciphertext, nil
 }
 
-func decryptCiphertexts(set *map[string]nothing, cache *cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
+func decryptCiphertexts(set *map[string]nothing, cache cache.Cache, provider *crypto.Provider, threads int, retries uint, timeout time.Duration, progress bool) error {
 	ciphertexts := make([]string, 0, len(*set))
 	for k := range *set {
 		ciphertexts = append(ciphertexts, k)
@@ -190,7 +190,7 @@ func decryptCiphertexts(set *map[string]nothing, cache *cache.Cache, provider *c
 	return err
 }
 
-func DecryptCiphertext(ciphertext []byte, cache *cache.Cache, provider *crypto.Provider, retries uint, timeout time.Duration) (string, error) {
+func DecryptCiphertext(ciphertext []byte, cache cache.Cache, provider *crypto.Provider, retries uint, timeout time.Duration) (string, error) {
 	plaintext, ok, err := cache.Decrypt(ciphertext)
 	if err != nil {
 		return "", fmt.Errorf("Error looking up ciphertext in cache: %w", err)

--- a/pkg/actions/git.go
+++ b/pkg/actions/git.go
@@ -3,17 +3,18 @@ package actions
 import (
 	"bufio"
 	"fmt"
-	"github.com/farmersedgeinc/yaml-crypt/pkg/cache"
-	"github.com/farmersedgeinc/yaml-crypt/pkg/config"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/farmersedgeinc/yaml-crypt/pkg/cache/disk"
+	"github.com/farmersedgeinc/yaml-crypt/pkg/config"
 )
 
 func UpdateGitignore(c *config.Config) error {
 	path := filepath.Join(c.Root, ".gitignore")
 	ignores := c.Suffixes.GitignoreSet()
-	ignores["/"+cache.CacheDirName] = true
+	ignores["/"+disk.CacheDirName] = true
 	if exists(path) {
 		existingFile, err := os.Open(path)
 		defer existingFile.Close()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,200 +1,22 @@
 package cache
 
 import (
-	"crypto/sha256"
-	"fmt"
-	"os"
-	"path/filepath"
-	"sync"
-
-	"git.mills.io/prologic/bitcask"
+	"github.com/farmersedgeinc/yaml-crypt/pkg/cache/disk"
+	"github.com/farmersedgeinc/yaml-crypt/pkg/cache/memory"
 	"github.com/farmersedgeinc/yaml-crypt/pkg/config"
 )
 
-const (
-	// Length to hash plaintext and ciphertext keys.
-	hashLength = 16
-	// Prefix for keys containing a hashed plaintext, used to look up ciphertext.
-	plaintextKeyPrefix = 'p'
-	// Prefix for keys containing a hashed ciphertext, used to look up plaintext.
-	ciphertextKeyPrefix = 'c'
-	// Name of the directory to store the caches in
-	CacheDirName = ".yamlcrypt.cache"
-)
-
-// Max young cache size: 100MiB by default (can be shrunk for tests)
-var YoungCacheSize int64 = 1024 * 1024 * 100
-
-// A quick and dirty "LRU-ish" cache.
-// Maintains a read/write "young" cache, and a read-only "old" cache.
-// New values are added to the "young" cache.
-// When looking up a value, if it's present in the "young" cache, retrieve it from there. If it's present in the "old" cache, retrieve it from there, copying it into the "young" cache.
-// When the "young" cache gets too big, the current "old" cache is removed and the current "young" cache takes its place. This only happens on close since the lifecycle of this object is expected to be pretty short in this application, but the benefit of this is: during a session, any values added to the cache are guaranteed to remain present until at least the end of the session (technically, until the end of the next session, due to the "old" cache).
-// Getting and inserting values are protected with a mutex, making this safe for parallel access, if a bit of a drag.
-type Cache struct {
-	parentPath string
-	young      *bitcask.Bitcask
-	youngPath  string
-	old        *bitcask.Bitcask
-	oldPath    string
-	mutex      sync.Mutex
+type Cache interface {
+	Close() error
+	Encrypt(plaintext string, potentialCiphertext []byte) ([]byte, bool, error)
+	Decrypt(ciphertext []byte) (string, bool, error)
+	Add(plaintext string, ciphertext []byte) error
 }
 
-// Initialize the cache.
-func Setup(config config.Config) (Cache, error) {
-	parentPath := filepath.Join(config.Root, CacheDirName)
-	cache := Cache{
-		parentPath: parentPath,
-		youngPath:  filepath.Join(parentPath, "young"),
-		oldPath:    filepath.Join(parentPath, CacheDirName, "old"),
+func Setup(config config.Config, mem bool) (Cache, error) {
+	if mem {
+		return memory.Setup()
+	} else {
+		return disk.Setup(config)
 	}
-	err := os.Mkdir(cache.parentPath, 0o700)
-	if err != nil && !os.IsExist(err) {
-		return cache, fmt.Errorf("Error creating new cache: %w", err)
-	}
-	cache.young, err = bitcask.Open(
-		cache.youngPath,
-		bitcask.WithAutoRecovery(true),
-		bitcask.WithFileFileModeBeforeUmask(0o600),
-		bitcask.WithDirFileModeBeforeUmask(0o700),
-	)
-	if err != nil {
-		return cache, fmt.Errorf("Error opening \"young\" cache: %w", err)
-	}
-	cache.old, err = bitcask.Open(
-		cache.oldPath,
-		bitcask.WithAutoRecovery(true),
-		bitcask.WithFileFileModeBeforeUmask(0o600),
-		bitcask.WithDirFileModeBeforeUmask(0o700),
-	)
-	if err != nil {
-		return cache, fmt.Errorf("Error opening \"old\" cache: %w", err)
-	}
-	return cache, err
-}
-
-// Close the cache, doing some cleanup as well. Must be called before exiting
-func (c *Cache) Close() error {
-	// we only need to merge young, because old is read-only
-	mergeErr := c.young.Merge()
-	stats, statsErr := c.young.Stats()
-	// we want to close if at all possible, so we'll handle merge/stats errors later
-	err := c.young.Close()
-	if err != nil {
-		return fmt.Errorf("Error closing \"young\" cache: %w", err)
-	}
-	err = c.old.Close()
-	if err != nil {
-		return fmt.Errorf("Error closing \"old\" cache: %w", err)
-	}
-	if mergeErr != nil {
-		return fmt.Errorf("Error merging \"young\" cache: %w", mergeErr)
-	}
-	if statsErr != nil {
-		return fmt.Errorf("Error getting cache stats: %w", mergeErr)
-	}
-	// if the young cache size is too big, get rid of the old cache and make the young cache take its place.
-	if stats.Size > YoungCacheSize {
-		err := os.RemoveAll(c.oldPath)
-		if err != nil {
-			return fmt.Errorf("Error deleting \"old\" cache: %w", err)
-		}
-		err = os.Rename(c.youngPath, c.oldPath)
-		if err != nil {
-			return fmt.Errorf("Error demoting \"young\" to \"old\" cache: %w", err)
-		}
-	}
-	return nil
-}
-
-// Look up the ciphertext for a given plaintext. Protected with a mutex.
-func (c *Cache) Encrypt(plaintext string, potentialCiphertext []byte) ([]byte, bool, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	// if the potentialCiphertext is in the cache, and has a plaintext equal to the plaintext being encrypted, that's the ciphertext!
-	if len(potentialCiphertext) > 0 {
-		potentialCiphertextPlaintext, ok, err := c.get(ciphertextToKey(potentialCiphertext))
-		if err != nil {
-			return []byte{}, false, fmt.Errorf("Error looking up potentialCiphertext in cache: %w", err)
-		}
-		if ok && string(potentialCiphertextPlaintext) == plaintext {
-			return potentialCiphertext, ok, nil
-		}
-	}
-	// potentialCiphertext wasn't it, so return an arbitrary ciphertext that encrypts the given plaintext.
-	ciphertext, ok, err := c.get(plaintextToKey(plaintext))
-	if err != nil {
-		return []byte{}, false, fmt.Errorf("Error looking up plaintext in cache: %w", err)
-	}
-	return ciphertext, ok, err
-}
-
-// Look up the plaintext for a given ciphertext. Protected with a mutex.
-func (c *Cache) Decrypt(ciphertext []byte) (string, bool, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	plaintext, ok, err := c.get(ciphertextToKey(ciphertext))
-	if err != nil {
-		err = fmt.Errorf("Error looking up ciphertext in cache: %w", err)
-	}
-	return string(plaintext), ok, err
-}
-
-// Add a (plaintext, ciphertext) pair to the young cache. Protected with a mutex.
-func (c *Cache) Add(plaintext string, ciphertext []byte) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	err := c.add(plaintext, ciphertext)
-	if err != nil {
-		return fmt.Errorf("Error adding item to cache: %w", err)
-	}
-	return nil
-}
-
-// Add a (plaintext, ciphertext) pair to the young cache.
-func (c *Cache) add(plaintext string, ciphertext []byte) error {
-	err := c.young.Put(plaintextToKey(plaintext), ciphertext)
-	if err != nil {
-		return err
-	}
-	return c.young.Put(ciphertextToKey(ciphertext), []byte(plaintext))
-}
-
-func (c *Cache) get(key []byte) (value []byte, ok bool, err error) {
-	if c.young.Has(key) {
-		value, err = c.young.Get(key)
-		ok = true
-	} else if c.old.Has(key) {
-		value, err = c.old.Get(key)
-		if err != nil {
-			err = fmt.Errorf("Error getting cache entry: %w", err)
-			return
-		}
-		ok = true
-		err = c.young.Put(key, value)
-	}
-	return
-}
-
-// Convert a ciphertext to the key used to lookup its plaintext.
-func ciphertextToKey(data []byte) []byte {
-	key := make([]byte, 1, hashLength+1)
-	key[0] = ciphertextKeyPrefix
-	key = append(key, hash(data)...)
-	return key
-}
-
-// Convert a plaintext to the key used to lookup its ciphertext.
-func plaintextToKey(data string) []byte {
-	key := make([]byte, 1, hashLength+1)
-	key[0] = plaintextKeyPrefix
-	key = append(key, hash([]byte(data))...)
-	return key
-}
-
-// Hash some bytes, truncating the length to the hashLength constant.
-func hash(data []byte) []byte {
-	result := sha256.Sum256(data)
-	return result[:hashLength]
 }

--- a/pkg/cache/common/common.go
+++ b/pkg/cache/common/common.go
@@ -1,0 +1,34 @@
+package common
+
+import "crypto/sha256"
+
+const (
+	// Length to hash plaintext and ciphertext keys.
+	hashLength = 16
+	// Prefix for keys containing a hashed plaintext, used to look up ciphertext.
+	plaintextKeyPrefix = 'p'
+	// Prefix for keys containing a hashed ciphertext, used to look up plaintext.
+	ciphertextKeyPrefix = 'c'
+)
+
+// Convert a plaintext to the key used to lookup its ciphertext.
+func PlaintextToKey(data string) []byte {
+	key := make([]byte, 1, hashLength+1)
+	key[0] = plaintextKeyPrefix
+	key = append(key, hash([]byte(data))...)
+	return key
+}
+
+// Hash some bytes, truncating the length to the hashLength constant.
+func hash(data []byte) []byte {
+	result := sha256.Sum256(data)
+	return result[:hashLength]
+}
+
+// Convert a ciphertext to the key used to lookup its plaintext.
+func CiphertextToKey(data []byte) []byte {
+	key := make([]byte, 1, hashLength+1)
+	key[0] = ciphertextKeyPrefix
+	key = append(key, hash(data)...)
+	return key
+}

--- a/pkg/cache/disk/cache.go
+++ b/pkg/cache/disk/cache.go
@@ -1,0 +1,172 @@
+package disk
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"git.mills.io/prologic/bitcask"
+	"github.com/farmersedgeinc/yaml-crypt/pkg/cache/common"
+	"github.com/farmersedgeinc/yaml-crypt/pkg/config"
+)
+
+const (
+	// Name of the directory to store the caches in
+	CacheDirName = ".yamlcrypt.cache"
+)
+
+// Max young cache size: 100MiB by default (can be shrunk for tests)
+var YoungCacheSize int64 = 1024 * 1024 * 100
+
+// A quick and dirty "LRU-ish" cache.
+// Maintains a read/write "young" cache, and a read-only "old" cache.
+// New values are added to the "young" cache.
+// When looking up a value, if it's present in the "young" cache, retrieve it from there. If it's present in the "old" cache, retrieve it from there, copying it into the "young" cache.
+// When the "young" cache gets too big, the current "old" cache is removed and the current "young" cache takes its place. This only happens on close since the lifecycle of this object is expected to be pretty short in this application, but the benefit of this is: during a session, any values added to the cache are guaranteed to remain present until at least the end of the session (technically, until the end of the next session, due to the "old" cache).
+// Getting and inserting values are protected with a mutex, making this safe for parallel access, if a bit of a drag.
+type diskCache struct {
+	parentPath string
+	young      *bitcask.Bitcask
+	youngPath  string
+	old        *bitcask.Bitcask
+	oldPath    string
+	mutex      sync.Mutex
+}
+
+// Initialize the cache.
+func Setup(config config.Config) (*diskCache, error) {
+	parentPath := filepath.Join(config.Root, CacheDirName)
+	cache := diskCache{
+		parentPath: parentPath,
+		youngPath:  filepath.Join(parentPath, "young"),
+		oldPath:    filepath.Join(parentPath, CacheDirName, "old"),
+	}
+	err := os.Mkdir(cache.parentPath, 0o700)
+	if err != nil && !os.IsExist(err) {
+		return nil, fmt.Errorf("Error creating new cache: %w", err)
+	}
+	cache.young, err = bitcask.Open(
+		cache.youngPath,
+		bitcask.WithAutoRecovery(true),
+		bitcask.WithFileFileModeBeforeUmask(0o600),
+		bitcask.WithDirFileModeBeforeUmask(0o700),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Error opening \"young\" cache: %w", err)
+	}
+	cache.old, err = bitcask.Open(
+		cache.oldPath,
+		bitcask.WithAutoRecovery(true),
+		bitcask.WithFileFileModeBeforeUmask(0o600),
+		bitcask.WithDirFileModeBeforeUmask(0o700),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Error opening \"old\" cache: %w", err)
+	}
+	return &cache, err
+}
+
+// Close the cache, doing some cleanup as well. Must be called before exiting
+func (c *diskCache) Close() error {
+	// we only need to merge young, because old is read-only
+	mergeErr := c.young.Merge()
+	stats, statsErr := c.young.Stats()
+	// we want to close if at all possible, so we'll handle merge/stats errors later
+	err := c.young.Close()
+	if err != nil {
+		return fmt.Errorf("Error closing \"young\" cache: %w", err)
+	}
+	err = c.old.Close()
+	if err != nil {
+		return fmt.Errorf("Error closing \"old\" cache: %w", err)
+	}
+	if mergeErr != nil {
+		return fmt.Errorf("Error merging \"young\" cache: %w", mergeErr)
+	}
+	if statsErr != nil {
+		return fmt.Errorf("Error getting cache stats: %w", mergeErr)
+	}
+	// if the young cache size is too big, get rid of the old cache and make the young cache take its place.
+	if stats.Size > YoungCacheSize {
+		err := os.RemoveAll(c.oldPath)
+		if err != nil {
+			return fmt.Errorf("Error deleting \"old\" cache: %w", err)
+		}
+		err = os.Rename(c.youngPath, c.oldPath)
+		if err != nil {
+			return fmt.Errorf("Error demoting \"young\" to \"old\" cache: %w", err)
+		}
+	}
+	return nil
+}
+
+// Look up the ciphertext for a given plaintext. Protected with a mutex.
+func (c *diskCache) Encrypt(plaintext string, potentialCiphertext []byte) ([]byte, bool, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// if the potentialCiphertext is in the cache, and has a plaintext equal to the plaintext being encrypted, that's the ciphertext!
+	if len(potentialCiphertext) > 0 {
+		potentialCiphertextPlaintext, ok, err := c.get(common.CiphertextToKey(potentialCiphertext))
+		if err != nil {
+			return []byte{}, false, fmt.Errorf("Error looking up potentialCiphertext in cache: %w", err)
+		}
+		if ok && string(potentialCiphertextPlaintext) == plaintext {
+			return potentialCiphertext, ok, nil
+		}
+	}
+	// potentialCiphertext wasn't it, so return an arbitrary ciphertext that encrypts the given plaintext.
+	ciphertext, ok, err := c.get(common.PlaintextToKey(plaintext))
+	if err != nil {
+		return []byte{}, false, fmt.Errorf("Error looking up plaintext in cache: %w", err)
+	}
+	return ciphertext, ok, err
+}
+
+// Look up the plaintext for a given ciphertext. Protected with a mutex.
+func (c *diskCache) Decrypt(ciphertext []byte) (string, bool, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	plaintext, ok, err := c.get(common.CiphertextToKey(ciphertext))
+	if err != nil {
+		err = fmt.Errorf("Error looking up ciphertext in cache: %w", err)
+	}
+	return string(plaintext), ok, err
+}
+
+// Add a (plaintext, ciphertext) pair to the young cache. Protected with a mutex.
+func (c *diskCache) Add(plaintext string, ciphertext []byte) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	err := c.add(plaintext, ciphertext)
+	if err != nil {
+		return fmt.Errorf("Error adding item to cache: %w", err)
+	}
+	return nil
+}
+
+// Add a (plaintext, ciphertext) pair to the young cache.
+func (c *diskCache) add(plaintext string, ciphertext []byte) error {
+	err := c.young.Put(common.PlaintextToKey(plaintext), ciphertext)
+	if err != nil {
+		return err
+	}
+	return c.young.Put(common.CiphertextToKey(ciphertext), []byte(plaintext))
+}
+
+func (c *diskCache) get(key []byte) (value []byte, ok bool, err error) {
+	if c.young.Has(key) {
+		value, err = c.young.Get(key)
+		ok = true
+	} else if c.old.Has(key) {
+		value, err = c.old.Get(key)
+		if err != nil {
+			err = fmt.Errorf("Error getting cache entry: %w", err)
+			return
+		}
+		ok = true
+		err = c.young.Put(key, value)
+	}
+	return
+}

--- a/pkg/cache/disk/cache_test.go
+++ b/pkg/cache/disk/cache_test.go
@@ -1,12 +1,13 @@
-package cache
+package disk
 
 import (
 	"bytes"
 	"fmt"
-	"github.com/farmersedgeinc/yaml-crypt/pkg/config"
-	"github.com/farmersedgeinc/yaml-crypt/pkg/fixtures"
 	"strconv"
 	"testing"
+
+	"github.com/farmersedgeinc/yaml-crypt/pkg/config"
+	"github.com/farmersedgeinc/yaml-crypt/pkg/fixtures"
 )
 
 func TestCache(t *testing.T) {
@@ -32,7 +33,7 @@ func TestCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	getItems(t, &cache, 0, false)
+	getItems(t, cache, 0, false)
 	err = cache.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -44,10 +45,10 @@ func TestCache(t *testing.T) {
 			t.Fatal(err)
 		}
 		// put this round's items
-		putItems(t, &cache, round)
+		putItems(t, cache, round)
 		// get this round's and the 4 previous rounds' items
 		for prevRound := round; prevRound >= round-4 && prevRound >= 0; prevRound-- {
-			getItems(t, &cache, prevRound, true)
+			getItems(t, cache, prevRound, true)
 		}
 		err = cache.Close()
 		if err != nil {
@@ -59,9 +60,9 @@ func TestCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	getItems(t, &cache, 0, false)
-	getItems(t, &cache, 1, false)
-	getItems(t, &cache, 19, true)
+	getItems(t, cache, 0, false)
+	getItems(t, cache, 1, false)
+	getItems(t, cache, 19, true)
 	err = cache.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +85,7 @@ func versionedCiphertext(round, item, version int) []byte {
 }
 
 // put items into the cache for a given round
-func putItems(t *testing.T, cache *Cache, round int) {
+func putItems(t *testing.T, cache *diskCache, round int) {
 	for item := 0; item < 100; item++ {
 		for version := 0; version < 3; version++ {
 			err := cache.Add(
@@ -99,7 +100,7 @@ func putItems(t *testing.T, cache *Cache, round int) {
 }
 
 // retrieve items from the cache associated with a given round
-func getItems(t *testing.T, cache *Cache, round int, shouldSucceed bool) {
+func getItems(t *testing.T, cache *diskCache, round int, shouldSucceed bool) {
 	for item := 0; item < 100; item++ {
 		for version := 0; item < 3; item++ {
 			ct, ok, err := cache.Encrypt(plaintext(round, item), versionedCiphertext(round, item, version))

--- a/pkg/cache/memory/cache.go
+++ b/pkg/cache/memory/cache.go
@@ -1,0 +1,52 @@
+package memory
+
+import (
+	"sync"
+
+	"github.com/farmersedgeinc/yaml-crypt/pkg/cache/common"
+)
+
+type memoryCache struct {
+	c map[string]string
+	m sync.RWMutex
+}
+
+func Setup() (*memoryCache, error) {
+	return &memoryCache{
+		c: map[string]string{},
+	}, nil
+}
+
+func (c *memoryCache) Close() error {
+	return nil
+}
+
+func (c *memoryCache) Add(plaintext string, ciphertext []byte) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.c[string(common.PlaintextToKey(plaintext))] = string(ciphertext)
+	c.c[string(common.CiphertextToKey(ciphertext))] = plaintext
+	return nil
+}
+
+func (c *memoryCache) Encrypt(plaintext string, potentialCiphertext []byte) ([]byte, bool, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	// if the potentialCiphertext is in the cache, and has a plaintext equal to the plaintext being encrypted, that's the ciphertext!
+	if len(potentialCiphertext) > 0 {
+		potentialCiphertextPlaintext, ok := c.c[string(common.CiphertextToKey(potentialCiphertext))]
+		if ok && string(potentialCiphertextPlaintext) == plaintext {
+			return potentialCiphertext, ok, nil
+		}
+	}
+	// potentialCiphertext wasn't it, so return an arbitrary ciphertext that encrypts the given plaintext.
+	ciphertext, ok := c.c[string(common.PlaintextToKey(plaintext))]
+	return []byte(ciphertext), ok, nil
+}
+
+func (c *memoryCache) Decrypt(ciphertext []byte) (string, bool, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	plaintext, ok := c.c[string(common.CiphertextToKey(ciphertext))]
+	return plaintext, ok, nil
+}

--- a/pkg/crypto/providers.go
+++ b/pkg/crypto/providers.go
@@ -34,19 +34,19 @@ func NewProvider(name string, config map[string]interface{}) (Provider, error) {
 	case "google":
 		project, err := getString(config, "project")
 		if err != nil {
-			err = err
+			return nil, err
 		}
 		location, err := getString(config, "location")
 		if err != nil {
-			err = err
+			return nil, err
 		}
 		keyring, err := getString(config, "keyring")
 		if err != nil {
-			err = err
+			return nil, err
 		}
 		key, err := getString(config, "key")
 		if err != nil {
-			err = err
+			return nil, err
 		}
 		provider = GoogleProvider{
 			Project:  project,
@@ -55,7 +55,7 @@ func NewProvider(name string, config map[string]interface{}) (Provider, error) {
 			Key:      key,
 		}
 	default:
-		err = fmt.Errorf("No provider named %s", name)
+		return nil, fmt.Errorf("No provider named %s", name)
 	}
 	return provider, err
 }
@@ -77,7 +77,8 @@ type Operation func(context.Context) error
 func retry(operation Operation, isRetryable func(error) bool, retries uint, timeout time.Duration) error {
 	var err error
 	for i := uint(0); i < retries; i++ {
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
 		err = operation(ctx)
 		if err != nil {
 			if !isRetryable(err) {

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -155,7 +155,7 @@ func StripTags(node *yaml.Node, tag string) {
 }
 
 // Turn a yaml Node tagged !encrypted into a yaml Node tagged !secret, by looking up its values in a give mapping of ciphertexts to plaintexts.
-func DecryptNode(node *yaml.Node, cache *cache.Cache) error {
+func DecryptNode(node *yaml.Node, cache cache.Cache) error {
 	// validate, read in data
 	if node.Tag != EncryptedTag {
 		return fmt.Errorf("Cannot decrypt a node not tagged %s", EncryptedTag)
@@ -183,7 +183,7 @@ func DecryptNode(node *yaml.Node, cache *cache.Cache) error {
 }
 
 // Turn a yaml Node tagged !secret into a yaml Node tagged !encrypted, looking up its values in a given mapping of plaintexts to ciphertexts.
-func EncryptNode(node *yaml.Node, possibleCiphertext []byte, cache *cache.Cache) error {
+func EncryptNode(node *yaml.Node, possibleCiphertext []byte, cache cache.Cache) error {
 	// validate, read in data
 	if node.Tag != DecryptedTag {
 		return fmt.Errorf("Cannot encrypt a node not tagged %s", DecryptedTag)


### PR DESCRIPTION
This is needed as argocd runs as read-only by default (plus it's just good practice). the cache is less important since `helm-secrets` just decrypts single values files on demand (compared to decrypting an entire repo full of yaml files).

We turn `Cache` into an interface, and move the `Cache` struct to a private struct that implements the interface. that way we can swap it out for a simple concurrent map structure that implements the same interface. The disk cache is definitely showing its age (it was clearly written before I had a great sense of when things should be pointers); I'll want to refactor that at some point